### PR TITLE
Add notice for max number of open orders for one market

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -961,6 +961,10 @@ request.post(options, function(error, response, body) {
 
 Use this endpoint to place a new order on the exchange
 
+<aside class="notice">
+You can only have a maximum of <strong>25 open orders</strong> at a time for one specific market
+</aside>
+
 ### HTTP Request
 
 `POST /exchange/v1/orders/create`


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->